### PR TITLE
Notifications index page - host location config

### DIFF
--- a/en/guide/notifications/index.md
+++ b/en/guide/notifications/index.md
@@ -4,6 +4,10 @@ Notifications in Beszel are defined using [Shoutrrr](https://github.com/containr
 
 Shoutrrr is a Go library originally developed for use in [Watchtower](https://github.com/containrrr/watchtower). We use a pinned version of a maintained fork, [nicholas-fedor/shoutrrr](https://github.com/nicholas-fedor/shoutrrr). The docs here are adapted from there.
 
+The URL for the webhook/push notification host can be set in the settings page.
+
+The alerts can be configured in the systems table.
+
 ## Services overview
 
 Click on the service for a more thorough explanation.


### PR DESCRIPTION
A small change in the Notifications index page to:
- Specify the location of the target server where notifications are to be sent.
- Noticed the `Looking instead for where to create alerts? Click the bell  icons in the systems table.` line in the settings page, so added that here as well.