### PR TITLE
Rename and revise Serve on Subpath page to document setting up a reverse proxy

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -102,7 +102,7 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
 				{ text: 'OAuth / OIDC', link: 'oauth' },
 				{ text: 'Podman Monitoring', link: 'podman' },
 				{ text: 'REST API', link: 'rest-api' },
-				{ text: 'Serve on Subpath', link: 'serve-on-subpath' },
+				{ text: 'Reverse Proxy', link: 'reverse-proxy' },
 				{ text: 'User Accounts', link: 'user-accounts' },
 				// { text: 'Home Assistant agent', link: 'home-assistant' },
 			],

--- a/en/guide/reverse-proxy.md
+++ b/en/guide/reverse-proxy.md
@@ -1,14 +1,20 @@
-# Serve on subpath
+# Reverse Proxy
 
-Beszel can be served on a subpath by setting the `APP_URL` environment variable and using a reverse proxy to forward requests to the subpath.
+Beszel can be served behind a reverse proxy. The reverse proxy must be configured to proxy WebSocket connections in order for agents setup with a universal token to connect to the hub.
 
-## Example configurations
+It is advisable to set the `APP_URL` environment variable because it is used for notification links and agent config generation.
+
+## Serve on subpath
+
+The reverse proxy and the `APP_URL` environment variable can be configured to serve Beszel on a subpath.
+
+### Example configurations for subpath
 
 ```bash
 APP_URL=https://beszel.example.com/base-path
 ```
 
-### Caddy
+#### Caddy
 
 ```text
 beszel.example.com {
@@ -26,7 +32,7 @@ beszel.example.com {
 }
 ```
 
-### Nginx
+#### Nginx
 
 ```nginx
 server {
@@ -52,7 +58,7 @@ server {
 }
 ```
 
-### Traefik
+#### Traefik
 
 ```yaml
 beszel:


### PR DESCRIPTION
I have chosen to rename the page rather than add a new page dedicated to reverse proxy documentation as in my own experience, the example configurations on the serve on subpath page was sufficient for me to figure out what the configuration should be for serving on the base path.

What was missing was the WebSocket part (and why), which I have elaborated on so that users wishing to setup say, an Apache reverse proxy, can keep that in mind. Unfortunately I no longer remember how to write Apache configurations, so I cannot provide an example for that.

The other thing was to clarify that `APP_URL` should be set even if the reverse proxy serves on the base path.

I have not made the change for the Mandarin translation though, as I don't trust my weak command of Mandarin. I could make an attempt with machine translation if that is acceptable. Alternatively, I could just change the paths while leaving titles and content intact so that the language switching toggle will not result in a 404.