### PR TITLE
use docker volume for docker run

### DIFF
--- a/en/guide/hub-installation.md
+++ b/en/guide/hub-installation.md
@@ -25,11 +25,11 @@ services:
 ```
 
 ```bash [docker run]
-mkdir -p ./beszel_data && \
+docker volume create beszel_data && \
 docker run -d \
   --name beszel \
   --restart=unless-stopped \
-  -v ./beszel_data:/beszel_data \
+  --volume beszel_data:/beszel_data \
   -p 8090:8090 \
   henrygd/beszel
 ```


### PR DESCRIPTION
changed local directory of ./beszel_data to docker volume.

For compose it makes sense to use local directory as the file will be saved, but docker recommends using volumes now, and for run it means no local file in the directory so less management.
