### PR TITLE
Add persistant sysctl to Intel GPU monitoring

### DIFF
--- a/en/guide/gpu.md
+++ b/en/guide/gpu.md
@@ -129,3 +129,10 @@ If that doesn't work, you may need to set a lower value for the `perf_event_para
 ```bash
 sudo sysctl kernel.perf_event_paranoid=2
 ```
+
+To make this change persistant across reboots you need to add it to the `sysctl` configuration
+
+```bash
+echo "kernel.perf_event_paranoid=2" | sudo tee /etc/sysctl.d/99-intel-gpu-beszel.conf
+sudo sysctl --system
+```

--- a/zh/guide/gpu.md
+++ b/zh/guide/gpu.md
@@ -129,3 +129,10 @@ sudo setcap cap_perfmon=ep /usr/bin/intel_gpu_top
 ```bash
 sudo sysctl kernel.perf_event_paranoid=2
 ```
+
+要让此更改在重启后依然生效，需要将其添加到 `sysctl` 配置中。
+
+```bash
+echo "kernel.perf_event_paranoid=2" | sudo tee /etc/sysctl.d/99-intel-gpu-beszel.conf
+sudo sysctl --system
+```


### PR DESCRIPTION
`kernel.perf_event_paranoid=2` is not persistent across reboots, this PR adds the command to make it persistent