### PR TITLE
[Docs] Add kubernetes deployment note on websocket timeouts with ingress controllers

### DIFF
--- a/en/guide/advanced-deployment.md
+++ b/en/guide/advanced-deployment.md
@@ -150,6 +150,21 @@ spec:
     type: RollingUpdate
 ```
 
+##### Note on WebSocket timeouts
+
+Whe using a Beszel Hub address (`HUB_URL`) on your Agents which is being served by an Ingess Controller like NGINX, make sure to increase the proxy read / send timeouts. Otherwise the connection will periodically abort and your nodes will be reported as offline.
+
+For the Kubernetes NGINX Ingress Controller, add a `proxy-read-timeout` and `proxy-send-timeout` annotation.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+```
+
 #### Adding Systems to Beszel
 
 Since we are using `hostNetwork: true` you use the Kubernetes node IP address when adding the system. **Note: This is NOT the internal Kubernetes IP but the physical IP of the node itself.** Each Kubernetes node only runs a single agent pod thus why this works.


### PR DESCRIPTION
I've deployed a Beszel hub and some agents on my kubernetes cluster. The beszel hub is exposed via an NGINX Ingress Controller. The agents also use the same Hub address.

With this setup, the WebSocket connection was dropped after 1-2min and re-connected. The nodes were then reported as offline.

```
2025/09/26 11:05:09 WARN Connection closed err=EOF
2025/09/26 11:05:09 WARN Disconnected from hub
```

When debugging this issue, I've found a [Stackoverflow thread](https://stackoverflow.com/a/52884066/4175566) which recommended to increase proxy read/send timeouts for the NGINX Ingress Controller. Haven't had a dropped connection since.

### Related Issues (maybe)

[#1060](https://github.com/henrygd/beszel/issues/1060)

### Sample

#### Ingress

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: nginx-ingress-beszel
  namespace: privileged-apps
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /
    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
    nginx.org/server-snippets: "gzip off;"
spec:
  ingressClassName: nginx
  rules:
    - host: "beszel.domain.tld"
      http:
        paths:
          - path: "/"
            pathType: Prefix
            backend:
              service:
                name: beszel-hub
                port:
                  name: beszel-http
```

#### Hub

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: beszel-hub
  labels:
    app: beszel-hub
spec:
  selector:
    matchLabels:
      app: beszel-hub
  template:
    metadata:
      name: beszel-hub
      labels:
        app: beszel-hub
    spec:
      containers:
        - image: henrygd/beszel:0.12.12
          imagePullPolicy: Always
          name: beszel-hub
          env:
            - name: LOG_LEVEL
              value: debug
          ports:
            - containerPort: 8090
              name: beszel-hub-http
          volumeMounts:
            - name: host-volume
              mountPath: /beszel_data
      volumes:
        - name: host-volume
          hostPath:
            path: /data
            type: DirectoryOrCreate
---
apiVersion: v1
kind: Service
metadata:
  name: beszel-hub
  namespace: privileged-apps
spec:
  type: ClusterIP
  ports:
    - targetPort: beszel-hub-http
      port: 8090
      name: beszel-http
  selector:
    app: beszel-hub
```

#### Agents

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: beszel-agent
spec:
  selector:
    matchLabels:
      app: beszel-agent
  template:
    metadata:
      labels:
        app: beszel-agent
    spec:
      hostNetwork: true
      containers:
        - image: henrygd/beszel-agent:0.12.12
          imagePullPolicy: Always
          name: beszel-agent
          env:
            - name: LOG_LEVEL
              value: info
            - name: LISTEN
              value: "45876"
            - name: KEY
              value: "REDACTED"
            - name: TOKEN
              value: "REDACTED"
            - name: HUB_URL
              value: "http://beszel.domain.tld" # <--- served by ingress controller
            - name: DOCKER_HOST
              value: "" # Disable docker monitoring
      restartPolicy: Always
      tolerations:
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
          operator: Exists
        - effect: NoSchedule
          key: node-role.kubernetes.io/control-plane
          operator: Exists
  updateStrategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 100%
    type: RollingUpdate
```