### PR TITLE
fix systemd docker volume path

### DIFF
--- a/en/guide/systemd.md
+++ b/en/guide/systemd.md
@@ -31,7 +31,7 @@ Mount the system D-Bus socket to allow the agent to communicate with systemd:
 services:
   beszel-agent:
     volumes:
-      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:ro
 ```
 
 If logs show an AppArmor error, add the following security option:

--- a/zh/guide/systemd.md
+++ b/zh/guide/systemd.md
@@ -31,7 +31,7 @@ Beszel 提供 systemd 服务的基本概览，显示其状态、CPU 使用率、
 services:
   beszel-agent:
     volumes:
-      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:ro
 ```
 
 如果日志显示 AppArmor 错误，请添加以下安全选项：


### PR DESCRIPTION
Following the original instructions results in this error with the agent in Docker:
```
WARN Error connecting to systemd err="dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory
```