### PR TITLE
Clarify how to grant access to the Podman socket

### DIFF
--- a/en/guide/podman.md
+++ b/en/guide/podman.md
@@ -13,34 +13,80 @@ systemctl --user start podman.socket
 
 Restart the agent to allow it to connect to the Podman API.
 
-## Permissions
+## Granting Permissions
 
-You must run the agent as the same user that runs Podman.
+The agent requires read/write access to the Podman socket. This can be achieved in various ways:
 
-::: code-group
+- creating a proxy socket
+- running the agent as the same user that runs Podman
+- changing the socket directory ownership and permissions
+- using ACLs
 
-```ini [beszel-agent.service]
+Below, only the first two methods are covered for binary agent and agent running in podman container, respectively.
+
+:::: details create a proxy socket for binary agent
+
+Сreate a proxy socket that the `beszel` user can access:
+
+```bash
+sudo groupadd podman-socket
+sudo usermod -aG podman-socket-proxy $USER
+sudo usermod -aG podman-socket-proxy beszel
+cat > ~/.config/systemd/user/podman-socket-proxy.service << 'EOF'
+[Unit]
+Description=Podman socket proxy for beszel
+After=network.target podman.socket
+Wants=podman.socket
+Requires=podman.socket
+
 [Service]
-User=beszel # [!code --]
-User=1000 # [!code ++]
+Type=simple
+ExecStartPre=/usr/bin/mkdir -p /run/podman-socket-proxy
+ExecStartPre=/usr/bin/chown %u:podman-socket-proxy /run/podman-socket-proxy
+ExecStart=/usr/bin/socat UNIX-LISTEN:/run/podman-socket-proxy/podman.sock,fork,user=%u,group=podman-socket-proxy,mode=0660 UNIX-CONNECT:%t/podman/podman.sock
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl --user daemon-reload
+systemctl --user enable --now podman-socket-proxy.service
 ```
 
-```bash [podman run]
+Add the `DOCKER_HOST` environment variable to your agent's service file `/etc/systemd/system/beszel-agent.service`:
+
+```ini
+[Service]
+Environment="DOCKER_HOST=unix:///run/podman-socket-proxy/podman.sock"  # [!code ++]
+```
+
+Restart the agent to allow it to connect to the Podman API.
+
+```bash
+sudo systemctl restart beszel-agent.service
+```
+
+::::
+
+:::: details Podman agent
+
+Mount the Podman socket directly:
+
+```bash
 podman run -d \
   --name beszel-agent \
   --user 1000 \
   --network host \
   --restart unless-stopped \
-  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v /run/user/1000/podman/podman.sock:/var/run/docker.sock:ro \
   -e KEY="<public key>" \
   -e LISTEN=45876 \
   docker.io/henrygd/beszel-agent:latest
 ```
 
-::: code-group
+::: tip Note
+Replace 1000 with your actual user ID if different. You can find it by running `id -u`
+:::
 
-## Specifying a different socket path
-
-The agent checks for the Podman socket at `/run/user/{uid}/podman/podman.sock`.
-
-If you need to use a different path, specify it in the `DOCKER_HOST` environment variable: `DOCKER_HOST=unix:///path/to/podman.sock`.
+::::


### PR DESCRIPTION
- Listed different methods
- Added info on creating a proxy socket
- Fixed a typo in `podman run` command