### PR TITLE
Update smart-data.md: docker-compose indentation one too deep

### DIFF
--- a/en/guide/smart-data.md
+++ b/en/guide/smart-data.md
@@ -43,12 +43,12 @@ Switch to the `:alpine` image and add the following to your `docker-compose.yml`
 ```yaml
 beszel-agent:
   image: henrygd/beszel-agent:alpine
-   devices:
-      - /dev/sda:/dev/sda
-      - /dev/nvme0:/dev/nvme0
-   cap_add:
-      - SYS_RAWIO # required for S.M.A.R.T. data
-      - SYS_ADMIN # required for NVMe S.M.A.R.T. data
+  devices:
+    - /dev/sda:/dev/sda
+    - /dev/nvme0:/dev/nvme0
+  cap_add:
+    - SYS_RAWIO # required for S.M.A.R.T. data
+    - SYS_ADMIN # required for NVMe S.M.A.R.T. data
 ```
 
 ::: tip Pass in the base controller name, not the block / partition


### PR DESCRIPTION
`devices` and `cap_add` were indented one blank too much.

I also added `:ro` on my local configuration, hoping that this restricts the container to read-only access.
Unfortunately I did not find any official documentation on `devices:` at docker.com