### PR TITLE
add power usage warning due to rtd3 to NVIDIA GPU docs

### DIFF
--- a/en/guide/gpu.md
+++ b/en/guide/gpu.md
@@ -59,6 +59,12 @@ systemctl daemon-reload
 systemctl restart beszel-agent
 ```
 
+### Power Usage Warning
+
+`nvidia-smi` prevents NVIDIA GPUs from entering RTD3 power saving mode which leads increased power consumption. On laptops this can drastically reduce idle battery life.
+
+You may prevent this by disabling GPU monitoring via `SKIP_GPU=true`. 
+
 ## Nvidia Jetson {#nvidia-jetson}
 
 You must use the binary agent and have `tegrastats` installed.


### PR DESCRIPTION
Spent many hours trying to figure out why my new laptop GPU refused to enter D3cold. Hopefully this will save others.

For additional context the RTX 5060 being stuck in D0 causes it to consume 5-7W of additional power on my Lenovo 16IAH10. This leads to a massive reduction in idle battery life:

(84 watt hours) / (16 watts) = 5.25 hours
(84 watt hours) / (10 watts) = 8.4 hours