### PR TITLE
Update S.M.A.R.T docker compose instructions

### DIFF
--- a/en/guide/smart-data.md
+++ b/en/guide/smart-data.md
@@ -38,11 +38,12 @@ sudo smartctl --scan
 
 Switch to the `:alpine` image and add the following to your `docker-compose.yml`. Make sure to replace the device names with your actual devices.
 
-> Non-base images like `beszel-agent-intel` and `beszel-agent-nvidia` also work.
+> Non-base images like `beszel-agent-intel` and `beszel-agent-nvidia` also work and dont require `:alpine`.
 
 ```yaml
 beszel-agent:
   image: henrygd/beszel-agent:alpine
+  privileged: true
   devices:
     - /dev/sda:/dev/sda
     - /dev/nvme0:/dev/nvme0


### PR DESCRIPTION
This pull request improves the clarity and accuracy of the S.M.A.R.T. Docker Compose documentation

Change 1:
Clarifies the instructions about switching to the `:alpine` image. The previous wording was confusing when using `beszel-agent-intel`, which does not have an Alpine tag. The updated text better explains when and why this step is required

Change 2:
Fixes the following error:

```bash
smartctl failed device=/dev/sda err="exit status 2"
```

This is resolved by running the agent container in privileged mode, which is required for proper access to S.M.A.R.T. device information