### PR TITLE
Docs: note eMMC and mdraid sysfs sources

### DIFF
--- a/en/guide/smart-data.md
+++ b/en/guide/smart-data.md
@@ -2,6 +2,10 @@
 
 Beszel parses S.M.A.R.T. data from `smartctl` and displays it on the system page if available. This usually requires increased permissions.
 
+::: tip Linux sysfs extras
+On Linux, Beszel also reads eMMC wear/EOL indicators and mdraid array health from sysfs. These do not require `smartctl`, but other disks still do.
+:::
+
 To make sure your system is compatible, install `smartmontools` on the agent machine and scan for devices: {#install}
 
 
@@ -281,4 +285,3 @@ sudo rm /etc/udev/rules.d/99-smartctl-disk-group.rules
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 ```
-

--- a/zh/guide/smart-data.md
+++ b/zh/guide/smart-data.md
@@ -2,6 +2,10 @@
 
 Beszel 从 `smartctl` 解析 S.M.A.R.T. 数据，并在系统页面上显示（如果可用）。这通常需要提升权限。
 
+::: tip Linux sysfs 额外支持
+在 Linux 上，Beszel 还会通过 sysfs 读取 eMMC 的磨损/寿命状态以及 mdraid 阵列健康信息。这些不需要 `smartctl`，但其他磁盘仍需要。
+:::
+
 要确保你的系统兼容，请在代理机器上安装 `smartmontools` 并扫描设备： {#install}
 
 ::: code-group


### PR DESCRIPTION
## Summary
- mention Linux sysfs eMMC wear/EOL and mdraid array health in SMART docs
## Testing
- n/a