### PR TITLE
Document S.M.A.R.T. failure notifications

### DIFF
--- a/en/guide/notifications/index.md
+++ b/en/guide/notifications/index.md
@@ -6,6 +6,8 @@ Shoutrrr is a Go library originally developed for use in [Watchtower](https://gi
 
 URLs are configured in settings (**Settings** > **Notifications**). Alerts are enabled in the systems table.
 
+If any disks report S.M.A.R.T. data to Beszel, a failure will automatically send a notification as long as at least one notification channel is configured. This behaviour is not currently configurable. See [S.M.A.R.T. Monitoring](../smart-data.md) for more details.
+
 ## Services overview
 
 Click on the service for a more thorough explanation.

--- a/en/guide/smart-data.md
+++ b/en/guide/smart-data.md
@@ -2,6 +2,8 @@
 
 Beszel parses S.M.A.R.T. data from `smartctl` and displays it on the system page if available. This usually requires increased permissions.
 
+If at least one notification channel is configured and disks report S.M.A.R.T. data to Beszel, a failure automatically triggers a notification. This behaviour is not currently configurable. Note: If a drive is already reporting failure on first detection by the Beszel agent, no alert will fire.
+
 ::: tip Linux sysfs extras
 On Linux, Beszel also reads eMMC wear/EOL indicators and mdraid array health from sysfs. These do not require `smartctl`, but other disks still do.
 :::

--- a/en/guide/what-is-beszel.md
+++ b/en/guide/what-is-beszel.md
@@ -25,6 +25,7 @@ It has a friendly web interface, simple configuration, and is ready to use out o
 - **Simple**: Easy setup, no need for public internet exposure.
 - **Docker stats**: Tracks CPU, memory, and network usage history for each container.
 - **Alerts**: Configurable alerts for CPU, memory, disk, bandwidth, temperature, load average, and status.
+- **S.M.A.R.T. alerts**: Automatic notifications on drive failure.
 - **Multi-user**: Users manage their own systems. Admins can share systems across users.
 - **OAuth / OIDC**: Supports many OAuth2 providers. Password auth can be disabled.
 - **Automatic backups**: Save and restore data from disk or S3-compatible storage.


### PR DESCRIPTION
As described in https://github.com/henrygd/beszel/discussions/1491, S.M.A.R.T. failures are notified automatically as long as at least one notification channel is configured. This behaviour was not documented.

This PR is missing its Chinese counterpart, if anyone would like to co-author this PR and add the Chinese translation that would be appreciated. Alternatively, I could add it myself using a LLM, but I have no way to check the output as I am not a Chinese speaker.

I've tested the documentation using `bun`.