### PR TITLE
docs: document fan-speed monitoring

### DIFF
--- a/en/guide/what-is-beszel.md
+++ b/en/guide/what-is-beszel.md
@@ -24,7 +24,7 @@ It has a friendly web interface, simple configuration, and is ready to use out o
 - **Lightweight**: Smaller and less resource-intensive than leading solutions.
 - **Simple**: Easy setup, no need for public internet exposure.
 - **Docker stats**: Tracks CPU, memory, and network usage history for each container.
-- **Alerts**: Configurable alerts for CPU, memory, disk, bandwidth, temperature, load average, and status.
+- **Alerts**: Configurable alerts for CPU, memory, disk, bandwidth, temperature, fan speed, load average, and status.
 - **S.M.A.R.T.**: Disk health data and notifications on drive failure.
 - **Multi-user**: Users manage their own systems. Admins can share systems across users.
 - **OAuth / OIDC**: Supports many OAuth2 providers. Password auth can be disabled.
@@ -61,5 +61,6 @@ Beszel consists of two main components: the **hub** and the **agent**.
 - **Network usage** - Host system and containers.
 - **Load average** - Host system.
 - **Temperature** - Host system sensors.
+- **Fan speed** - Host system sensors (Linux, via `/sys/class/hwmon`).
 - **GPU usage / power draw** - Nvidia, AMD, and Intel.
 - **Battery** - Host system battery charge.


### PR DESCRIPTION
Companion to [henrygd/beszel#2032](https://github.com/henrygd/beszel/pull/2032) which adds fan RPM collection from `/sys/class/hwmon` plus a `FanSpeed` alert type.

Two-line update to `en/guide/what-is-beszel.md`:

- Listed **Fan speed** under "Supported metrics" right after Temperature, mentioning the Linux / `/sys/class/hwmon` source so users know what to expect on other platforms.
- Added "fan speed" to the Alerts feature line so the supported-alerts list stays in sync.

No other pages touched — there are no new env vars (no `FANS_TIMEOUT`, no `PRIMARY_FAN`) and the chart/alert UI is self-explanatory. Happy to expand to a dedicated page if you'd prefer.