### PR TITLE
add voidauth to the list of supported selfhosted oauth providers

### DIFF
--- a/en/guide/oauth.md
+++ b/en/guide/oauth.md
@@ -79,4 +79,5 @@ This is not a complete list, just providers known to work. If you're using somet
 - Keycloak
 - mailcow
 - [Pocket ID](https://pocket-id.org/docs/client-examples/beszel)
+- [VoidAuth](https://voidauth.app/#/OIDC-Guides?id=-beszel)
 - ZITADEL


### PR DESCRIPTION
as the title says, voidauth works well as an oauth provider, and they have a guide on how to set it up with beszel