### PR TITLE
document failed services alert

### DIFF
--- a/en/guide/environment-variables.md
+++ b/en/guide/environment-variables.md
@@ -154,6 +154,8 @@ Comma-separated list of glob patterns to match systemd service names. Services m
 SERVICE_PATTERNS="beszel*,docker*,kubelet*"
 ```
 
+Only matched services are eligible to trigger the [Failed Services alert](./systemd.md#alerts).
+
 ### `SMART_DEVICES`
 
 Used to override the devices detected by `smartctl --scan`. Each device is specified as a colon-separated pair of the device path and (optionally) the device type. For example:

--- a/en/guide/systemd.md
+++ b/en/guide/systemd.md
@@ -17,6 +17,14 @@ Notes:
 - Peak memory usage covers the entire lifetime of the service if provided by systemd. Otherwise, it is the maximum memory usage during the monitoring period.
 - Services will show 0% CPU usage on first connection. This is normal behavior - CPU usage will populate correctly on the next update cycle.
 
+## Alerts
+
+Enable the **Failed Services** alert (bell icon on a system, or the **All Systems** tab) to get notified when any tracked service enters the `failed` state, and again once all previously failed services recover. The notification names the affected services, e.g. "2 failed services on web01: nginx, fail2ban".
+
+This alert is system-wide — it fires on any failed service, and there's no way to select individual services. Which services are tracked at all is controlled by `SERVICE_PATTERNS` (see [Environment Variables](./environment-variables.md#service_patterns)); a service must match one of those patterns to be alertable.
+
+There's no delay/duration setting for this alert, unlike CPU, Memory, etc. It fires as soon as a failed service is observed. The agent only refreshes systemd state every 10 minutes, so a failure can take up to about that long to be noticed — restarting the agent forces an immediate refresh. Because of this polling interval, transient failures that self-heal quickly are often never observed.
+
 ## Binary agent
 
 When running the agent as a binary, no additional configuration is typically required for systemd monitoring. The agent runs with sufficient privileges to access systemd service information.


### PR DESCRIPTION
Adds documentation for the new "Failed Services" alert, tracked in henrygd/beszel#1813 and henrygd/beszel#2173. 

- Added an "Alerts" subsection to `systemd.md`, following the same pattern used for S.M.A.R.T. failure notifications in `smart-data.md`: how to enable it, that it's system-wide with no per-service selection, that there's no delay/duration setting, and the ~10-minute detection latency from the agent's systemd polling interval.
- Cross-linked from the `SERVICE_PATTERNS` entry in `environment-variables.md`, since only matched services are eligible to trigger the alert.

No new page was added – alert types aren't documented in a central page anywhere else in these docs, so this keeps the doc next to the feature it describes rather than starting a page that would need to be kept in sync with every other alert type.