### PR TITLE
docs: add Intel sysfs GPU collector

### DIFF
--- a/en/guide/environment-variables.md
+++ b/en/guide/environment-variables.md
@@ -19,7 +19,7 @@ Environment variables may optionally be prefixed with `BESZEL_HUB_`.
 | `HEARTBEAT_URL`         | unset   | External URL to ping periodically. Enables [heartbeat monitoring](#heartbeat-monitoring). Feature is disabled if empty.                      |
 | `MFA_OTP`               | false   | Enables OTP authentication for users and/or superusers.                                                                                     |
 | `OAUTH_DISABLE_POPUP`   | false   | Disables the OAuth2 popup window. Useful when OAuth is used behind a reverse proxy or in embedded browser environments.                      |
-| `SHARE_ALL_SYSTEMS`     | false   | Allows access to all systems by all users.                                                                                                  |
+| `SHARE_ALL_SYSTEMS`     | false   | Allows access to all systems by all users. Users can also edit or delete any system unless they are assigned the `readonly` role.            |
 | `TRUSTED_AUTH_HEADER`   | unset   | Trusted header for forwarded authentication.                                                                                                |
 | `USER_CREATION`         | false   | Enables automatic user creation for OAuth2 / OIDC.                                                                                          |
 | `USER_EMAIL`            | unset   | Create first user with this email.                                                                                                          |
@@ -53,7 +53,7 @@ The redirect flow requires users to register their app's base URL (e.g., `https:
 
 If set via environment variables, these values take precedence and the settings page becomes read-only.
 
-When `HEARTBEAT_URL` is set, Beszel sends a periodic outbound ping to the specified URL (e.g. a [Healthchecks.io](https://healthchecks.io), [BetterStack](https://betterstack.com), or [Uptime Kuma](https://github.com/louislam/uptime-kuma) endpoint). This lets you monitor the health of your Beszel instance itself using a dead man's switch approach — if pings stop arriving, the external service alerts you.
+When `HEARTBEAT_URL` is set, Beszel sends a periodic outbound ping to the specified URL (e.g., a [Healthchecks.io](https://healthchecks.io), [BetterStack](https://betterstack.com), or [Uptime Kuma](https://github.com/louislam/uptime-kuma) endpoint). This lets you monitor the health of your Beszel instance itself using a dead man's switch approach — if pings stop arriving, the external service alerts you.
 
 When using the default `POST` method, Beszel sends a JSON payload with a summary of the current state:
 
@@ -174,16 +174,17 @@ When set to `true`, the agent exits immediately on a DNS lookup failure instead 
 
 Comma-separated list of collectors to try in order. Overrides the default auto-detection priority. Valid values:
 
-| Value          | Description                                      |
-| -------------- | ------------------------------------------------ |
-| `nvtop`        | nvtop (multi-vendor)                             |
-| `nvml`         | NVIDIA Management Library (requires `NVML=true`) |
-| `nvidia-smi`   | NVIDIA System Management Interface               |
-| `intel_gpu_top`| Intel GPU top                                    |
-| `amd_sysfs`    | AMD sysfs interface                              |
-| `rocm-smi`     | AMD ROCm System Management Interface             |
-| `macmon`       | macmon (Apple Silicon)                           |
-| `powermetrics` | powermetrics (macOS)                             |
+| Value           | Description                                      |
+| --------------- | ------------------------------------------------ |
+| `nvtop`         | nvtop (multi-vendor)                             |
+| `nvml`          | NVIDIA Management Library (requires `NVML=true`) |
+| `nvidia-smi`    | NVIDIA System Management Interface               |
+| `intel_sysfs`   | Intel sysfs interface                            |
+| `intel_gpu_top` | Intel GPU top                                    |
+| `amd_sysfs`     | AMD sysfs interface                              |
+| `rocm-smi`      | AMD ROCm System Management Interface             |
+| `macmon`        | macmon (Apple Silicon)                           |
+| `powermetrics`  | powermetrics (macOS)                             |
 
 Example: `GPU_COLLECTOR=nvml,nvidia-smi` tries NVML first, falling back to nvidia-smi.
 
@@ -214,7 +215,7 @@ Default depends on the address value. If the address starts with `/`, it is trea
 Treated as a whitelist by default. Can be used as a blacklist by prefixing with `-`.
 
 | `NICS` value   | Mode      | Action                                                    |
-| -------------- | --------- | --------------------------------------------------------- |
+| --------------- | --------- | --------------------------------------------------------- |
 | `foo_*`        | Whitelist | Only interfaces matching `foo_*` are allowed.             |
 | `foo_1,bar_*`  | Whitelist | Only `foo_1` and `bar_*` interfaces allowed.              |
 | `-foo_*`       | Blacklist | Excludes interfaces matching `foo_*`; all others allowed. |
@@ -232,10 +233,10 @@ Treated as a whitelist by default. Can be used as a blacklist by prefixing with 
 | `SENSORS` value | Mode      | Action                                                 |
 | --------------- | --------- | ------------------------------------------------------ |
 | `foo_*`         | Whitelist | Only sensors matching `foo_*` are allowed.             |
-| `foo_1,bar_*`   | Whitelist | Only `foo_1` and `bar_*` sensors allowed.              |
+| `foo_1,bar_*`   | Whitelist | Only sensors matching `foo_1` and `bar_*` are allowed. |
 | `-foo_*`        | Blacklist | Excludes sensors matching `foo_*`; all others allowed. |
-| `-foo_1,bar_*`  | Blacklist | Excludes `foo_1` and `bar_*`; all others allowed.      |
-| `""`            | Disabled  | Disable temperature monitoring with an empty string.   |
+| `-foo_1,bar_*` | Blacklist | Excludes `foo_1` and `bar_*`; all others allowed.      |
+| `""`           | Disabled  | Disable temperature monitoring with an empty string.   |
 
 ### `SERVICE_PATTERNS`
 

--- a/en/guide/gpu.md
+++ b/en/guide/gpu.md
@@ -21,7 +21,8 @@ The agent automatically detects available GPU monitoring tools and selects the b
 | `nvidia-smi`    | NVIDIA System Management Interface (default).                          |
 | `amd_sysfs`     | Direct sysfs monitoring for AMD GPUs.                                  |
 | `rocm-smi`      | ROCm System Management Interface (default if installed).               |
-| `intel_gpu_top` | Intel GPU monitoring (default for Intel GPUs).                         |
+| `intel_sysfs`   | Direct sysfs monitoring for Intel GPUs on Linux.                       |
+| `intel_gpu_top` | Intel GPU monitoring.                                                  |
 | `tegrastats`    | NVIDIA Jetson monitoring (default for NVIDIA Jetson).                  |
 | `nvtop`         | Multi-vendor. Requires `nvtop` 3.3.2+. Cannot be combined with others. |
 | `macmon`        | macOS GPU monitoring (Apple Silicon, experimental).                    |
@@ -130,13 +131,17 @@ sudo ln -s /opt/rocm/bin/rocm-smi /usr/local/bin/rocm-smi
 
 ## Intel GPUs {#intel}
 
-Available collectors: `intel_gpu_top`, `nvtop`.
+Available collectors: `intel_sysfs`, `intel_gpu_top`, `nvtop`.
+
+On Linux, `intel_sysfs` is automatically detected when compatible Intel DRM hwmon energy counters are available. It reads power and temperature directly from sysfs and does not require additional userspace tools. You can select it explicitly with `GPU_COLLECTOR=intel_sysfs`.
+
+With the Xe kernel driver, GPU utilization and memory usage are unavailable because the required sysfs attributes are not exposed. Power monitoring is still supported.
 
 Note that only one Intel GPU per system is supported with `intel_gpu_top`.
 
 ### Docker agent {#intel-docker}
 
-Use the `henrygd/beszel-agent-intel` image with the additional options below.
+For `intel_gpu_top`, use the `henrygd/beszel-agent-intel` image with the additional options below.
 
 ```yaml
 beszel-agent:
@@ -155,7 +160,7 @@ ls /dev/dri
 
 ### Binary agent {#intel-binary}
 
-You must have `intel_gpu_top` or `nvtop` installed.
+For `intel_gpu_top` or `nvtop`, install the appropriate tool. `intel_sysfs` does not require either tool.
 
 ::: code-group
 

--- a/en/guide/gpu.md
+++ b/en/guide/gpu.md
@@ -21,7 +21,7 @@ The agent automatically detects available GPU monitoring tools and selects the b
 | `nvidia-smi`    | NVIDIA System Management Interface (default).                          |
 | `amd_sysfs`     | Direct sysfs monitoring for AMD GPUs.                                  |
 | `rocm-smi`      | ROCm System Management Interface (default if installed).               |
-| `intel_sysfs`   | Direct sysfs monitoring for Intel GPUs on Linux.                       |
+| `intel_sysfs`   | Direct sysfs monitoring for Intel GPUs on Linux (limited metrics).     |
 | `intel_gpu_top` | Intel GPU monitoring.                                                  |
 | `tegrastats`    | NVIDIA Jetson monitoring (default for NVIDIA Jetson).                  |
 | `nvtop`         | Multi-vendor. Requires `nvtop` 3.3.2+. Cannot be combined with others. |
@@ -133,15 +133,39 @@ sudo ln -s /opt/rocm/bin/rocm-smi /usr/local/bin/rocm-smi
 
 Available collectors: `intel_sysfs`, `intel_gpu_top`, `nvtop`.
 
-On Linux, `intel_sysfs` is automatically detected when compatible Intel DRM hwmon energy counters are available. It reads power and temperature directly from sysfs and does not require additional userspace tools. You can select it explicitly with `GPU_COLLECTOR=intel_sysfs`.
+### Intel Arc / Xe driver
 
-With the Xe kernel driver, GPU utilization and memory usage are unavailable because the required sysfs attributes are not exposed. Power monitoring is still supported.
+Intel GPUs using the Xe kernel driver are supported through `nvtop`. Beszel automatically skips `intel_gpu_top` on Xe systems and uses `nvtop` when available.
 
-Note that only one Intel GPU per system is supported with `intel_gpu_top`.
+`nvtop` provides GPU usage, temperature, power, and memory metrics on Xe. In Docker, add `pid: host` to the agent service for GPU utilization; without it, utilization reports 0% while temperature, power, and memory remain available.
+
+### `intel_sysfs`
+
+On Linux, `intel_sysfs` is automatically detected when compatible Intel DRM hwmon energy counters are available. It has no userspace tool dependency, but metric availability is limited to what the kernel exposes through sysfs and varies by driver and hardware.
+
+On Xe, `intel_sysfs` can report power and temperature when those hwmon attributes are available, but GPU utilization and memory usage are not exposed. For more complete Xe monitoring, use `nvtop`.
+
+You can select the sysfs collector explicitly with `GPU_COLLECTOR=intel_sysfs`.
+
+### `intel_gpu_top`
+
+`intel_gpu_top` is supported for Intel GPUs using the i915 driver, but not the Xe driver. Only one Intel GPU per system is supported with this collector.
 
 ### Docker agent {#intel-docker}
 
-For `intel_gpu_top`, use the `henrygd/beszel-agent-intel` image with the additional options below.
+Use the `henrygd/beszel-agent-intel` image.
+
+For Xe / Intel Arc, add `pid: host` to enable GPU utilization through `nvtop`:
+
+```yaml
+beszel-agent:
+  image: henrygd/beszel-agent-intel
+  pid: host
+  devices:
+    - /dev/dri:/dev/dri
+```
+
+For `intel_gpu_top` on i915, add `CAP_PERFMON` and expose the GPU device:
 
 ```yaml
 beszel-agent:

--- a/zh/guide/environment-variables.md
+++ b/zh/guide/environment-variables.md
@@ -19,7 +19,7 @@
 | `HEARTBEAT_URL`         | 未设置 | 定期 ping 的外部 URL。启用[心跳监控](#heartbeat-monitoring)。为空时禁用此功能。                                                  |
 | `MFA_OTP`               | false  | 为用户和/或超级用户启用 OTP 认证。                                                                                               |
 | `OAUTH_DISABLE_POPUP`   | false  | 禁用 OAuth2 弹出窗口。适用于反向代理或嵌入式浏览器环境中使用 OAuth 的场景。                                                      |
-| `SHARE_ALL_SYSTEMS`     | false  | 允许所有用户访问所有系统。                                                                                                       |
+| `SHARE_ALL_SYSTEMS`     | false  | 允许所有用户访问所有系统。除非用户被分配了 `readonly` 角色，否则他们还可以编辑或删除任何系统。                                    |
 | `TRUSTED_AUTH_HEADER`   | 未设置 | 用于转发身份验证的可信头。                                                                                                       |
 | `USER_CREATION`         | false  | 启用 OAuth2 / OIDC 的自动用户创建。                                                                                              |
 | `USER_EMAIL`            | 未设置 | 使用此邮箱创建第一个用户。                                                                                                       |
@@ -175,6 +175,7 @@ Docker 套接字代理通过过滤 API 请求，提供了比直接连接 `docker
 | `nvtop`          | nvtop（多厂商）                                   |
 | `nvml`           | NVIDIA 管理库（需要 `NVML=true`）                 |
 | `nvidia-smi`     | NVIDIA 系统管理接口                               |
+| `intel_sysfs`    | Intel sysfs 接口                                  |
 | `intel_gpu_top`  | Intel GPU top                                     |
 | `amd_sysfs`      | AMD sysfs 接口                                    |
 | `rocm-smi`       | AMD ROCm 系统管理接口                             |

--- a/zh/guide/gpu.md
+++ b/zh/guide/gpu.md
@@ -21,7 +21,8 @@ Agent 会自动检测可用的 GPU 监控工具并为您的系统选择最佳工
 | `nvidia-smi`    | NVIDIA 系统管理接口（默认）。                           |
 | `amd_sysfs`     | 针对 AMD GPU 的直接 sysfs 监控。                        |
 | `rocm-smi`      | ROCm 系统管理接口（如果已安装则为默认）。               |
-| `intel_gpu_top` | Intel GPU 监控（Intel GPU 的默认设置）。                |
+| `intel_sysfs`   | 针对 Linux 上 Intel GPU 的直接 sysfs 监控（指标有限）。 |
+| `intel_gpu_top` | Intel GPU 监控。                                        |
 | `tegrastats`    | NVIDIA Jetson 监控（NVIDIA Jetson 的默认设置）。        |
 | `nvtop`         | 多厂商。需要 `nvtop` 3.3.2+。不能与其他收集器结合使用。 |
 | `macmon`        | macOS GPU 监控（Apple Silicon，实验性）。               |
@@ -130,13 +131,41 @@ sudo ln -s /opt/rocm/bin/rocm-smi /usr/local/bin/rocm-smi
 
 ## Intel GPU {#intel}
 
-可用收集器：`intel_gpu_top`、`nvtop`。
+可用收集器：`intel_sysfs`、`intel_gpu_top`、`nvtop`。
 
-请注意，使用 `intel_gpu_top` 时，每个系统仅支持一个 Intel GPU。
+### Intel Arc / Xe 驱动程序
+
+使用 Xe 内核驱动程序的 Intel GPU 通过 `nvtop` 提供支持。在 Xe 系统上，Beszel 会自动跳过 `intel_gpu_top`，并在可用时使用 `nvtop`。
+
+`nvtop` 在 Xe 上提供 GPU 使用率、温度、功耗和内存指标。在 Docker 中，为 GPU 使用率请在代理服务中添加 `pid: host`；不添加的话使用率会显示为 0%，但温度、功耗和内存仍然可用。
+
+### `intel_sysfs`
+
+在 Linux 上，当存在兼容的 Intel DRM hwmon 能量计数器时，会自动检测到 `intel_sysfs`。它不依赖任何用户空间工具，但指标的可用性仅限于内核通过 sysfs 暴露的内容，并因驱动程序和硬件而异。
+
+在 Xe 上，当存在相应的 hwmon 属性时，`intel_sysfs` 可以报告功耗和温度，但不暴露 GPU 使用率和内存使用情况。要获得更完整的 Xe 监控，请使用 `nvtop`。
+
+您可以通过 `GPU_COLLECTOR=intel_sysfs` 显式选择 sysfs 收集器。
+
+### `intel_gpu_top`
+
+`intel_gpu_top` 支持使用 i915 驱动程序的 Intel GPU，但不支持 Xe 驱动程序。使用此收集器时，每个系统仅支持一个 Intel GPU。
 
 ### Docker Agent {#intel-docker}
 
-使用 `henrygd/beszel-agent-intel` 镜像并添加以下额外选项。
+使用 `henrygd/beszel-agent-intel` 镜像。
+
+对于 Xe / Intel Arc，请添加 `pid: host` 以通过 `nvtop` 启用 GPU 使用率：
+
+```yaml
+beszel-agent:
+  image: henrygd/beszel-agent-intel
+  pid: host
+  devices:
+    - /dev/dri:/dev/dri
+```
+
+对于 i915 上的 `intel_gpu_top`，请添加 `CAP_PERFMON` 并暴露 GPU 设备：
 
 ```yaml
 beszel-agent:
@@ -155,7 +184,7 @@ ls /dev/dri
 
 ### 二进制 Agent {#intel-binary}
 
-您必须安装 `intel_gpu_top` 或 `nvtop`。
+对于 `intel_gpu_top` 或 `nvtop`，请安装相应的工具。`intel_sysfs` 不需要这两种工具。
 
 ::: code-group
 


### PR DESCRIPTION
## Summary

- document the `intel_sysfs` GPU collector added in henrygd/beszel#2020
- clarify Intel Xe driver metric limitations and tool requirements
- add `intel_sysfs` to the `GPU_COLLECTOR` reference