### PR TITLE
Include NVMe drive mapping note in smart-data guide

### DIFF
--- a/en/guide/smart-data.md
+++ b/en/guide/smart-data.md
@@ -106,6 +106,18 @@ DeviceAllow=/dev/sda r
 DeviceAllow=/dev/nvme0 r
 ```
 
+::: warning Some NVMe drives require mapping to the partition
+
+Some drive manufacturers (e.g., Intel) require mapping the host partition to the controller name for S.M.A.R.T. data to work properly. If you see missing capacity information or other issues, try:
+
+```ini
+DeviceAllow=/dev/nvme0n1 r
+```
+
+See [issue #1637](https://github.com/henrygd/beszel/issues/1637) for more details.
+
+:::
+
 3. Reload and restart:
 
 ```bash


### PR DESCRIPTION
Added warning about NVMe drive mapping for S.M.A.R.T. data to the binary install section. It's the same warning as in the `docker-agent` section, but with the appropriate line for updating a service file. Perhaps these warnings would be better served (less redundant) if they were briefly called out in the docker-agent and binary install sections with a pointer to the troubleshooting section where this warning could live in one place and list the config change solution for both docker and binary there. That way the entire warning message isn't "code duplication" in the two separate sections where it currently lives.

This is the PR I mentioned [here](https://github.com/henrygd/beszel/issues/2172#issuecomment-5382854532).