### PR TITLE
Clarify NVMe S.M.A.R.T. device guidance

### DIFF
--- a/en/guide/smart-data.md
+++ b/en/guide/smart-data.md
@@ -66,9 +66,9 @@ Note that we are using `sda` and `nvme0` in our example, not `sda1` or `nvme0n1`
 
 :::
 
-::: warning Some NVMe drives require mapping to the partition
+::: warning Some NVMe drives require access to the namespace device
 
-Some drive manufacturers (e.g., Intel) require mapping the host partition to the controller name for S.M.A.R.T. data to work properly. If you see missing capacity information or other issues, try:
+Some NVMe drives may only report complete S.M.A.R.T. information, such as capacity, when accessed through the namespace device (for example, `/dev/nvme0n1`) rather than the controller (`/dev/nvme0`). For Docker, map the namespace device to the controller path:
 
 ```yaml
 devices:
@@ -106,9 +106,9 @@ DeviceAllow=/dev/sda r
 DeviceAllow=/dev/nvme0 r
 ```
 
-::: warning Some NVMe drives require mapping to the partition
+::: warning Some NVMe drives require access to the namespace device
 
-Some drive manufacturers (e.g., Intel) require mapping the host partition to the controller name for S.M.A.R.T. data to work properly. If you see missing capacity information or other issues, try:
+Some NVMe drives may only report complete S.M.A.R.T. information, such as capacity, when accessed through the namespace device (for example, `/dev/nvme0n1`) rather than the controller (`/dev/nvme0`). For a systemd installation, also allow access to the namespace device:
 
 ```ini
 DeviceAllow=/dev/nvme0n1 r
@@ -193,7 +193,7 @@ If your system cannot find the `smartctl` executable, you will need to manually 
 
 To add smartctl to your PATH:
 
-1. Open the **Edit the system environment variables** dialog:
+1. Open the **Edit system environment variables** dialog:
    - Press `Win + R`, type `sysdm.cpl`, press Enter and go the Advanced tab.
    - Or search for "Environment Variables" in the Start menu
 

--- a/en/guide/smart-data.md
+++ b/en/guide/smart-data.md
@@ -193,7 +193,7 @@ If your system cannot find the `smartctl` executable, you will need to manually 
 
 To add smartctl to your PATH:
 
-1. Open the **Edit system environment variables** dialog:
+1. Open the **Edit the system environment variables** dialog:
    - Press `Win + R`, type `sysdm.cpl`, press Enter and go the Advanced tab.
    - Or search for "Environment Variables" in the Start menu
 

--- a/zh/guide/smart-data.md
+++ b/zh/guide/smart-data.md
@@ -65,9 +65,9 @@ beszel-agent:
 
 :::
 
-::: warning 某些 NVMe 驱动器需要映射到分区
+::: warning 某些 NVMe 驱动器需要访问命名空间设备
 
-某些驱动器制造商（例如 Intel）需要将主机分区映射到控制器名称，才能使 S.M.A.R.T. 数据正常工作。如果你看到缺少容量信息或其他问题，请尝试：
+某些 NVMe 驱动器可能只有通过命名空间设备（例如 `/dev/nvme0n1`）而不是控制器（`/dev/nvme0`）访问时，才能报告完整的 S.M.A.R.T. 信息，例如容量。对于 Docker，请将命名空间设备映射到控制器路径：
 
 ```yaml
 devices:
@@ -104,6 +104,18 @@ CapabilityBoundingSet=CAP_SYS_RAWIO CAP_SYS_ADMIN
 DeviceAllow=/dev/sda r
 DeviceAllow=/dev/nvme0 r
 ```
+
+::: warning 某些 NVMe 驱动器需要访问命名空间设备
+
+某些 NVMe 驱动器可能只有通过命名空间设备（例如 `/dev/nvme0n1`）而不是控制器（`/dev/nvme0`）访问时，才能报告完整的 S.M.A.R.T. 信息，例如容量。对于 systemd 安装，还需要允许访问命名空间设备：
+
+```ini
+DeviceAllow=/dev/nvme0n1 r
+```
+
+详情请参见 [issue #1637](https://github.com/henrygd/beszel/issues/1637)。
+
+:::
 
 3. 重新加载并重启：
 


### PR DESCRIPTION
Clarifies the NVMe namespace-device warning in both the Docker and binary agent sections.

- Docker: explains that the namespace device should be mapped to the controller path.
- Binary/systemd: explains that the namespace device should be added with `DeviceAllow`.
- Avoids describing the systemd configuration as a device mapping.

Follow-up to #70.