### PR TITLE
docs: add ZFS systemd device access fallback

### DIFF
--- a/en/guide/zfs.md
+++ b/en/guide/zfs.md
@@ -30,6 +30,15 @@ Mapping `/dev/zfs` is required — without it the ZFS commands cannot communicat
 
 The binary agent needs `zpool` and `zfs` available to its user on the host, which OpenZFS provides on Proxmox, TrueNAS, and most distributions that ship ZFS.
 
+If ZFS pools are not detected when running the agent as a systemd service, you may need to allow access to the ZFS control device:
+
+```ini
+[Service]
+DeviceAllow=/dev/zfs rw
+```
+
+After updating the service, reload systemd and restart the agent.
+
 ## What is displayed
 
 - **Pools table** — each pool with its health state, capacity, allocation, and scrub status.

--- a/zh/guide/zfs.md
+++ b/zh/guide/zfs.md
@@ -30,6 +30,15 @@ beszel-agent:
 
 二进制代理需要其用户可以在宿主机上访问 `zpool` 和 `zfs`，Proxmox、TrueNAS 以及大多数自带 ZFS 的发行版都提供 OpenZFS。
 
+如果在 systemd 服务中运行代理时未检测到 ZFS 存储池，可能需要显式允许访问 ZFS 控制设备。将以下内容添加到服务配置中：
+
+```ini
+[Service]
+DeviceAllow=/dev/zfs rw
+```
+
+然后重新加载 systemd 并重启代理。
+
 ## 显示内容
 
 - **存储池表格** — 显示每个存储池的健康状态、容量、已分配空间和清理（scrub）状态。


### PR DESCRIPTION
Adds a troubleshooting note for binary agents running under systemd. If ZFS pools are not detected, the service may need explicit access to `/dev/zfs` via `DeviceAllow=/dev/zfs rw`.

This is documented as a fallback rather than a general requirement, since many systemd installations work without it.