### PR TITLE
docs: clarify NVIDIA slim image support

### DIFF
--- a/en/guide/gpu.md
+++ b/en/guide/gpu.md
@@ -56,6 +56,13 @@ beszel-agent:
             capabilities:
               - utility
 ```
+### Slim image variant {#nvidia-slim}
+
+The slim image uses a distroless base and does not bundle a shell, package manager, or `nvidia-smi`.
+
+The NVIDIA Container Toolkit on the host system mounts the NVIDIA utilities and driver components required for `nvidia-smi` and `nvml` into the container.
+
+Use `henrygd/beszel-agent-nvidia:slim` with the same NVIDIA Container Toolkit configuration shown above.
 
 ### Binary agent {#nvidia-binary}
 

--- a/zh/guide/gpu.md
+++ b/zh/guide/gpu.md
@@ -57,6 +57,14 @@ beszel-agent:
               - utility
 ```
 
+### Slim 镜像变体 {#nvidia-slim}
+
+slim 镜像使用 distroless 基础镜像，不包含 shell、包管理器或 `nvidia-smi`。
+
+主机系统上的 NVIDIA Container Toolkit 会将 `nvidia-smi` 和 `nvml` 所需的 NVIDIA 工具和驱动组件挂载到容器中。
+
+使用 `henrygd/beszel-agent-nvidia:slim`，并采用上文所示的相同 NVIDIA Container Toolkit 配置即可。
+
 ### 二进制 Agent {#nvidia-binary}
 
 您可能需要在服务配置中允许访问您的设备。有关更多信息，请参阅 [discussion #563](https://github.com/henrygd/beszel/discussions/563#discussioncomment-12230389)。


### PR DESCRIPTION


A bit late, but following the discussion in https://github.com/henrygd/beszel/pull/2003, I've added concise documentation for the slim NVIDIA image.

I tested the slim image with the existing Compose Deploy Specification configuration, and it works with the current Docker agent setup.

This change adds a brief note about the slim image and how it works with the NVIDIA Container Toolkit.